### PR TITLE
feat: Add trackingAuthorizationStatus for showing a custom explainer dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.1.0
-* FEATURE: Added canRequestTrackingAuthorization()
+* FEATURE: Added trackingAuthorizationStatus
 
 ## 1.0.1+1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+* FEATURE: Added canRequestTrackingAuthorization()
+
 ## 1.0.1+1
 
 * Improved documentation

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ final status = await AppTrackingTransparency.requestTrackingAuthorization();
 // FirebaseAdMob.instance.initialize(...)
 ```
 
+You can also show a custom explainer dialog before the system dialog if you want.
+```dart
+if (await AppTrackingTransparency.canRequestTrackingAuthorization()) {
+  // Show a custom explainer dialog before the system dialog
+  if (await showCustomTrackingDialog(context)) {
+    // Wait for dialog popping animation
+    await Future.delayed(const Duration(milliseconds: 200));
+    // Platform messages may fail, so we use a try/catch PlatformException.
+    try {
+      await AppTrackingTransparency.requestTrackingAuthorization();
+    } on PlatformException {
+      // Failed to open tracking auth dialog.
+    }
+  }
+}
+```
+
 You can also get advertising identifier after authorization. Until a user grants authorization, the UUID returned will be all zeros: 00000000-0000-0000-0000-000000000000. Also note, the advertisingIdentifier will be all zeros in the Simulator, regardless of the tracking authorization status.
 ```dart
 final uuid = await AppTrackingTransparency.getAdvertisingIdentifier();

--- a/README.md
+++ b/README.md
@@ -46,18 +46,20 @@ final status = await AppTrackingTransparency.requestTrackingAuthorization();
 
 You can also show a custom explainer dialog before the system dialog if you want.
 ```dart
-if (await AppTrackingTransparency.canRequestTrackingAuthorization()) {
-  // Show a custom explainer dialog before the system dialog
-  if (await showCustomTrackingDialog(context)) {
-    // Wait for dialog popping animation
-    await Future.delayed(const Duration(milliseconds: 200));
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    try {
+try {
+  // If the system can show an authorization request dialog
+  if (await AppTrackingTransparency.trackingAuthorizationStatus ==
+      TrackingStatus.notDetermined) {
+    // Show a custom explainer dialog before the system dialog
+    if (await showCustomTrackingDialog(context)) {
+      // Wait for dialog popping animation
+      await Future.delayed(const Duration(milliseconds: 200));
+      // Request system's tracking authorization dialog
       await AppTrackingTransparency.requestTrackingAuthorization();
-    } on PlatformException {
-      // Failed to open tracking auth dialog.
     }
   }
+} on PlatformException {
+  // Unexpected exception was thrown
 }
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,12 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
 
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(CupertinoApp(home: MyApp()));
 }
 
 class MyApp extends StatefulWidget {
@@ -19,41 +20,67 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-    initPlugin();
+    // Can't show a dialog in initState, delaying initialization
+    SchedulerBinding.instance.addPostFrameCallback((_) => initPlugin());
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlugin() async {
     TrackingStatus status;
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    try {
-      status = await AppTrackingTransparency.requestTrackingAuthorization();
-    } on PlatformException {
-      _authStatus = 'Failed to open tracking auth dialog.';
+
+    if (await AppTrackingTransparency.canRequestTrackingAuthorization()) {
+      // Show a custom explainer dialog before the system dialog
+      if (await showCustomTrackingDialog(context)) {
+        // Wait for dialog popping animation
+        await Future.delayed(const Duration(milliseconds: 200));
+        // Platform messages may fail, so we use a try/catch PlatformException.
+        try {
+          status = await AppTrackingTransparency.requestTrackingAuthorization();
+        } on PlatformException {
+          _authStatus = 'Failed to open tracking auth dialog.';
+        }
+        setState(() {
+          _authStatus = "$status";
+        });
+      }
     }
 
     final uuid = await AppTrackingTransparency.getAdvertisingIdentifier();
     print("UUID: $uuid");
-
-    if (!mounted) {
-      return;
-    }
-
-    setState(() {
-      _authStatus = "$status";
-    });
   }
+
+  Future<bool> showCustomTrackingDialog(BuildContext context) =>
+      showCupertinoDialog<bool>(
+        context: context,
+        builder: (context) => CupertinoAlertDialog(
+          title: const Text('Explain Title'),
+          content: const Text('Explain Description'),
+          actions: [
+            CupertinoDialogAction(
+              onPressed: () => Navigator.pop(context, false),
+              child: SizedBox(
+                // Force vertical layout
+                width: MediaQuery.of(context).size.width / 2,
+                child: const Text("I'll decide later"),
+              ),
+            ),
+            CupertinoDialogAction(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Allow tracking'),
+            ),
+          ],
+        ),
+      ) ??
+      false;
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('App Tracking Transparency Example'),
-        ),
-        body: Center(
-          child: Text('Tracking status: $_authStatus\n'),
-        ),
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        middle: const Text('App Tracking Transparency Example'),
+      ),
+      child: Center(
+        child: Text('Tracking status: $_authStatus\n'),
       ),
     );
   }

--- a/ios/Classes/SwiftAppTrackingTransparencyPlugin.swift
+++ b/ios/Classes/SwiftAppTrackingTransparencyPlugin.swift
@@ -13,8 +13,10 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    
-    if (call.method == "requestTrackingAuthorization") {
+    if (call.method == "canRequestTrackingAuthorization") {
+        canRequestTrackingAuthorization(result: result)
+    }
+    else if (call.method == "requestTrackingAuthorization") {
         requestTrackingAuthorization(result: result)
     }
     else if (call.method == "getAdvertisingIdentifier") {
@@ -23,7 +25,18 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
     else {
         result(FlutterMethodNotImplemented)
     }
-    
+  }
+
+  private func canRequestTrackingAuthorization(result: @escaping FlutterResult) {
+    if #available(iOS 14, *) {
+        #if canImport(AppTrackingTransparency)
+            result(Bool(ATTrackingManager.trackingAuthorizationStatus == ATTrackingManager.AuthorizationStatus.notDetermined))
+        #else
+            result(Bool(false))
+        #endif
+    } else {
+        result(Bool(false))
+    }
   }
 
   /*
@@ -33,9 +46,8 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
     case authorized = 3
   */
   private func requestTrackingAuthorization(result: @escaping FlutterResult) {
-        
     if #available(iOS 14, *) {
-         #if canImport(AppTrackingTransparency)
+        #if canImport(AppTrackingTransparency)
         ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
 
             switch status {
@@ -43,7 +55,7 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
                     // Tracking authorization dialog was shown
                     // and we are authorized
                     print("requestTrackingAuthorization: Authorized")
-                
+
                     // Now that we are authorized we can get the IDFA
                     // print(ASIdentifierManager.shared().advertisingIdentifier)
                 case .denied:
@@ -58,7 +70,7 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
                 @unknown default:
                     print("requestTrackingAuthorization: Unknown")
             }
-            
+
             result(Int(status.rawValue));
 
         })
@@ -69,11 +81,9 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
         // Fallback on earlier versions
         result(Int(0));
     }
-        
   }
-    
+
   private func getAdvertisingIdentifier(result: @escaping FlutterResult) {
     result(String(ASIdentifierManager.shared().advertisingIdentifier.uuidString))
   }
-
 }

--- a/ios/Classes/SwiftAppTrackingTransparencyPlugin.swift
+++ b/ios/Classes/SwiftAppTrackingTransparencyPlugin.swift
@@ -3,7 +3,7 @@ import UIKit
 #if canImport(AppTrackingTransparency)
     import AppTrackingTransparency
 #endif
-import AdSupport;
+import AdSupport
 
 public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -13,8 +13,8 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    if (call.method == "canRequestTrackingAuthorization") {
-        canRequestTrackingAuthorization(result: result)
+    if (call.method == "getTrackingAuthorizationStatus") {
+        getTrackingAuthorizationStatus(result: result)
     }
     else if (call.method == "requestTrackingAuthorization") {
         requestTrackingAuthorization(result: result)
@@ -27,15 +27,17 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  private func canRequestTrackingAuthorization(result: @escaping FlutterResult) {
+  private func getTrackingAuthorizationStatus(result: @escaping FlutterResult) {
     if #available(iOS 14, *) {
         #if canImport(AppTrackingTransparency)
-            result(Bool(ATTrackingManager.trackingAuthorizationStatus == ATTrackingManager.AuthorizationStatus.notDetermined))
+            result(Int(ATTrackingManager.trackingAuthorizationStatus.rawValue))
         #else
-            result(Bool(false))
+            // return notSupported
+            result(Int(4))
         #endif
     } else {
-        result(Bool(false))
+        // return notSupported
+        result(Int(4))
     }
   }
 
@@ -48,38 +50,16 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
   private func requestTrackingAuthorization(result: @escaping FlutterResult) {
     if #available(iOS 14, *) {
         #if canImport(AppTrackingTransparency)
-        ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
-
-            switch status {
-                case .authorized:
-                    // Tracking authorization dialog was shown
-                    // and we are authorized
-                    print("requestTrackingAuthorization: Authorized")
-
-                    // Now that we are authorized we can get the IDFA
-                    // print(ASIdentifierManager.shared().advertisingIdentifier)
-                case .denied:
-                    // Tracking authorization dialog was
-                    // shown and permission is denied
-                    print("requestTrackingAuthorization: Denied")
-                case .notDetermined:
-                    // Tracking authorization dialog has not been shown
-                    print("requestTrackingAuthorization: Not Determined")
-                case .restricted:
-                    print("requestTrackingAuthorization: Restricted")
-                @unknown default:
-                    print("requestTrackingAuthorization: Unknown")
-            }
-
-            result(Int(status.rawValue));
-
-        })
+            ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
+                result(Int(status.rawValue))
+            })
         #else
-        result(Int(0));
+            // return notSupported
+            result(Int(4))
         #endif
     } else {
-        // Fallback on earlier versions
-        result(Int(0));
+        // return notSupported
+        result(Int(4))
     }
   }
 

--- a/ios/Classes/SwiftAppTrackingTransparencyPlugin.swift
+++ b/ios/Classes/SwiftAppTrackingTransparencyPlugin.swift
@@ -1,8 +1,6 @@
 import Flutter
 import UIKit
-#if canImport(AppTrackingTransparency)
-    import AppTrackingTransparency
-#endif
+import AppTrackingTransparency
 import AdSupport
 
 public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
@@ -29,12 +27,7 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
 
   private func getTrackingAuthorizationStatus(result: @escaping FlutterResult) {
     if #available(iOS 14, *) {
-        #if canImport(AppTrackingTransparency)
-            result(Int(ATTrackingManager.trackingAuthorizationStatus.rawValue))
-        #else
-            // return notSupported
-            result(Int(4))
-        #endif
+        result(Int(ATTrackingManager.trackingAuthorizationStatus.rawValue))
     } else {
         // return notSupported
         result(Int(4))
@@ -49,14 +42,9 @@ public class SwiftAppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
   */
   private func requestTrackingAuthorization(result: @escaping FlutterResult) {
     if #available(iOS 14, *) {
-        #if canImport(AppTrackingTransparency)
-            ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
-                result(Int(status.rawValue))
-            })
-        #else
-            // return notSupported
-            result(Int(4))
-        #endif
+        ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
+            result(Int(status.rawValue))
+        })
     } else {
         // return notSupported
         result(Int(4))

--- a/lib/app_tracking_transparency.dart
+++ b/lib/app_tracking_transparency.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/services.dart';
 
 enum TrackingStatus { notDetermined, restricted, denied, authorized }
@@ -6,6 +7,40 @@ enum TrackingStatus { notDetermined, restricted, denied, authorized }
 class AppTrackingTransparency {
   static const MethodChannel _channel =
       const MethodChannel('app_tracking_transparency');
+
+  /// This function returns true if platform is iOS, iOS version is 14.0+ and
+  /// authorization status is not determined. If you want to show a custom
+  /// tracking explainer dialog before the system dialog, consider calling this
+  /// function before [requestTrackingAuthorization]. This ensures that the
+  /// system will show the dialog if the custom tracking dialog accepted.
+  ///
+  /// ```dart
+  /// if (await AppTrackingTransparency.canRequestTrackingAuthorization()) {
+  ///   // Show a custom explainer dialog before the system dialog
+  ///   if (await showCustomTrackingDialog(context)) {
+  ///     // Wait for dialog popping animation
+  ///     await Future.delayed(const Duration(milliseconds: 200));
+  ///     // Platform messages may fail, so we use a try/catch PlatformException.
+  ///     try {
+  ///       await AppTrackingTransparency.requestTrackingAuthorization();
+  ///     } on PlatformException {
+  ///       // Failed to open tracking auth dialog.
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Returns true if the system can show the tracking request dialog.
+  static Future<bool> canRequestTrackingAuthorization() async {
+    if (Platform.isIOS) {
+      try {
+        final bool isAvailable =
+            await _channel.invokeMethod('canRequestTrackingAuthorization');
+        return isAvailable;
+      } on PlatformException {}
+    }
+    return false;
+  }
 
   /// Call this function to display tracking authorization dialog on ios 14+ devices.
   /// User's choice is returned as [TrackingStatus]. You can call this function as many


### PR DESCRIPTION
Showing an explainer dialog before the system's tracking request dialog is recommended. So I add the `canRequestTrackingAuthorization` function for checking that the system can show a request dialog or not.

```dart
if (await AppTrackingTransparency.canRequestTrackingAuthorization()) {
  // Show a custom explainer dialog before the system dialog
  if (await showCustomTrackingDialog(context)) {
    // Wait for dialog popping animation
    await Future.delayed(const Duration(milliseconds: 200));
    // Platform messages may fail, so we use a try/catch PlatformException.
    try {
      await AppTrackingTransparency.requestTrackingAuthorization();
    } on PlatformException {
      // Failed to open tracking auth dialog.
    }
  }
}
```