### PR TITLE
refactor: Migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+* Migrated to null safety.
+
 ## 1.1.0+1
 
 * Formatted dart files.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 
@@ -18,8 +17,7 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
-    // Can't show a dialog in initState, delaying initialization
-    SchedulerBinding.instance.addPostFrameCallback((_) => initPlugin());
+    initPlugin();
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
@@ -47,7 +45,6 @@ class _HomePageState extends State<HomePage> {
 
     final uuid = await AppTrackingTransparency.getAdvertisingIdentifier();
     print("UUID: $uuid");
-
   }
 
   Future<bool> showCustomTrackingDialog(BuildContext context) async =>
@@ -58,7 +55,7 @@ class _HomePageState extends State<HomePage> {
           content: const Text(
             'We care about your privacy and data security. We keep this app free by showing ads. '
             'Can we continue to use your data to tailor ads for you?\n\nYou can change your choice anytime in the app settings. '
-            'Our partners will collect data and use a unique identifier on your device to show you ads.'
+            'Our partners will collect data and use a unique identifier on your device to show you ads.',
           ),
           actions: [
             TextButton(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the app_tracking_transparency plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -19,10 +19,6 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
 
 dev_dependencies:
   flutter_test:

--- a/lib/app_tracking_transparency.dart
+++ b/lib/app_tracking_transparency.dart
@@ -46,7 +46,7 @@ class AppTrackingTransparency {
   static Future<TrackingStatus> get trackingAuthorizationStatus async {
     if (Platform.isIOS) {
       final int status =
-          (await _channel.invokeMethod('getTrackingAuthorizationStatus'))!;
+          (await _channel.invokeMethod<int>('getTrackingAuthorizationStatus'))!;
       return TrackingStatus.values[status];
     }
     return TrackingStatus.notSupported;
@@ -64,7 +64,7 @@ class AppTrackingTransparency {
   static Future<TrackingStatus> requestTrackingAuthorization() async {
     if (Platform.isIOS) {
       final int status =
-          (await _channel.invokeMethod('requestTrackingAuthorization'))!;
+          (await _channel.invokeMethod<int>('requestTrackingAuthorization'))!;
       return TrackingStatus.values[status];
     }
     return TrackingStatus.notSupported;
@@ -78,7 +78,7 @@ class AppTrackingTransparency {
   static Future<String> getAdvertisingIdentifier() async {
     if (Platform.isIOS) {
       final String uuid =
-          (await _channel.invokeMethod('getAdvertisingIdentifier'))!;
+          (await _channel.invokeMethod<String>('getAdvertisingIdentifier'))!;
       return uuid;
     }
     return "";

--- a/lib/app_tracking_transparency.dart
+++ b/lib/app_tracking_transparency.dart
@@ -46,7 +46,7 @@ class AppTrackingTransparency {
   static Future<TrackingStatus> get trackingAuthorizationStatus async {
     if (Platform.isIOS) {
       final int status =
-          await _channel.invokeMethod('getTrackingAuthorizationStatus');
+          (await _channel.invokeMethod('getTrackingAuthorizationStatus'))!;
       return TrackingStatus.values[status];
     }
     return TrackingStatus.notSupported;
@@ -64,7 +64,7 @@ class AppTrackingTransparency {
   static Future<TrackingStatus> requestTrackingAuthorization() async {
     if (Platform.isIOS) {
       final int status =
-          await _channel.invokeMethod('requestTrackingAuthorization');
+          (await _channel.invokeMethod('requestTrackingAuthorization'))!;
       return TrackingStatus.values[status];
     }
     return TrackingStatus.notSupported;
@@ -78,7 +78,7 @@ class AppTrackingTransparency {
   static Future<String> getAdvertisingIdentifier() async {
     if (Platform.isIOS) {
       final String uuid =
-          await _channel.invokeMethod('getAdvertisingIdentifier');
+          (await _channel.invokeMethod('getAdvertisingIdentifier'))!;
       return uuid;
     }
     return "";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: app_tracking_transparency
 description: This Flutter plugin allows you to display ios tracking authorization dialogue and request permission to collect data.
-version: 1.1.0+1
+version: 2.0.0
 homepage: https://github.com/deniza/app_tracking_transparency
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.20.0 <2.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/app_tracking_transparency_test.dart
+++ b/test/app_tracking_transparency_test.dart
@@ -1,32 +1,25 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 
+// Flutter tests run on desktop (e.g. windows), so Platform.isIOS is always false.
+// When the platform isn't iOS, this package's methods return notSupported or "".
+// So this test can be useful for android. Because, on android, this package
+// shouldn't throw an error, it should always return notSupported/"".
+// On iOS, testing only needs to be done manually.
+
 void main() {
-  const MethodChannel channel = MethodChannel('app_tracking_transparency');
-
-  TestWidgetsFlutterBinding.ensureInitialized();
-
-  setUp(() async {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      switch (methodCall.method) {
-        case 'requestTrackingAuthorization':
-          return 0;
-        case 'getAdvertisingIdentifier':
-          return "0";
-        default:
-          return null;
-      }
-    });
+  test('trackingAuthorizationStatus', () async {
+    final status = await AppTrackingTransparency.trackingAuthorizationStatus;
+    expect(status, TrackingStatus.notSupported);
   });
 
   test('requestTrackingAuthorization', () async {
     final status = await AppTrackingTransparency.requestTrackingAuthorization();
-    expect(status, isNotNull);
+    expect(status, TrackingStatus.notSupported);
   });
 
   test('getAdvertisingIdentifier', () async {
     final uuid = await AppTrackingTransparency.getAdvertisingIdentifier();
-    expect(uuid, isNotNull);
+    expect(uuid, "");
   });
 }


### PR DESCRIPTION
Flutter 2.0 released. Now every package should be migrated to null safety.

[Sound null safety](https://dart.dev/null-safety)
[Migrating to null safety](https://dart.dev/null-safety/migration-guide)

closes #5