### PR TITLE
Remove decide later button in explainer dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # app_tracking_transparency
 
+[![pub package](https://img.shields.io/pub/v/app_tracking_transparency.svg)](https://pub.dev/packages/app_tracking_transparency)
+
 This Flutter plugin allows you to display ios 14+ tracking authorization dialog and request permission to collect data. Collected data is crucial for ad networks (ie admob) to work efficiently on ios 14+ devices.
 
 ## Introduction
@@ -40,24 +42,21 @@ final status = await AppTrackingTransparency.requestTrackingAuthorization();
 // FirebaseAdMob.instance.initialize(...)
 ```
 
-You can also show a custom explainer dialog before the system dialog if you want.
+Google (admob) recommends implementing an explainer message that appears to users immediately before the consent dialogue. For additional info on this topic please refer to this article: https://support.google.com/admob/answer/9997589?hl=en
 ```dart
-try {
-  // If the system can show an authorization request dialog
-  if (await AppTrackingTransparency.trackingAuthorizationStatus ==
-      TrackingStatus.notDetermined) {
-    // Show a custom explainer dialog before the system dialog
-    if (await showCustomTrackingDialog(context)) {
-      // Wait for dialog popping animation
-      await Future.delayed(const Duration(milliseconds: 200));
-      // Request system's tracking authorization dialog
-      await AppTrackingTransparency.requestTrackingAuthorization();
-    }
-  }
-} on PlatformException {
-  // Unexpected exception was thrown
+// If the system can show an authorization request dialog
+if (await AppTrackingTransparency.trackingAuthorizationStatus ==
+    TrackingStatus.notDetermined) {
+  // Show a custom explainer dialog before the system dialog
+  await showCustomTrackingDialog(context);
+  // Wait for dialog popping animation
+  await Future.delayed(const Duration(milliseconds: 200));
+  // Request system's tracking authorization dialog
+  await AppTrackingTransparency.requestTrackingAuthorization();
 }
 ```
+
+The explainer dialog must not contain a "Decide later" button. It should contain only a "Continue" button and the system dialog must be shown after the explainer dialog. [See this issue for details](https://github.com/deniza/app_tracking_transparency/issues/27).
 
 You can also get advertising identifier after authorization. Until a user grants authorization, the UUID returned will be all zeros: 00000000-0000-0000-0000-000000000000. Also note, the advertisingIdentifier will be all zeros in the Simulator, regardless of the tracking authorization status.
 ```dart
@@ -66,8 +65,6 @@ final uuid = await AppTrackingTransparency.getAdvertisingIdentifier();
 
 ## Notes
 To use this plugin you should compile your project using XCode 12 and run your app on an ios 14 device.
-
-Google (admob) recommends implementing an explainer message that appears to users immediately before the consent dialogue. For additional info on this topic please refer to this article: <https://support.google.com/admob/answer/9997589?hl=en>
 
 ## Important Notice
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 
 void main() {
-  runApp(MaterialApp(home: HomePage()));
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: HomePage(),
+    );
+  }
 }
 
 class HomePage extends StatefulWidget {
@@ -17,39 +25,32 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
-    // Can't show a dialog in initState, delaying initialization
-    WidgetsBinding.instance!.addPostFrameCallback((_) => initPlugin());
+    initPlugin();
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlugin() async {
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    try {
+    final TrackingStatus status =
+        await AppTrackingTransparency.trackingAuthorizationStatus;
+    setState(() => _authStatus = '$status');
+    // If the system can show an authorization request dialog
+    if (status == TrackingStatus.notDetermined) {
+      // Show a custom explainer dialog before the system dialog
+      await showCustomTrackingDialog(context);
+      // Wait for dialog popping animation
+      await Future.delayed(const Duration(milliseconds: 200));
+      // Request system's tracking authorization dialog
       final TrackingStatus status =
-          await AppTrackingTransparency.trackingAuthorizationStatus;
+          await AppTrackingTransparency.requestTrackingAuthorization();
       setState(() => _authStatus = '$status');
-      // If the system can show an authorization request dialog
-      if (status == TrackingStatus.notDetermined) {
-        // Show a custom explainer dialog before the system dialog
-        if (await showCustomTrackingDialog(context)) {
-          // Wait for dialog popping animation
-          await Future.delayed(const Duration(milliseconds: 200));
-          // Request system's tracking authorization dialog
-          final TrackingStatus status =
-              await AppTrackingTransparency.requestTrackingAuthorization();
-          setState(() => _authStatus = '$status');
-        }
-      }
-    } on PlatformException {
-      setState(() => _authStatus = 'PlatformException was thrown');
     }
 
     final uuid = await AppTrackingTransparency.getAdvertisingIdentifier();
     print("UUID: $uuid");
   }
 
-  Future<bool> showCustomTrackingDialog(BuildContext context) async =>
-      await showDialog<bool>(
+  Future<void> showCustomTrackingDialog(BuildContext context) async =>
+      await showDialog<void>(
         context: context,
         builder: (context) => AlertDialog(
           title: const Text('Dear User'),
@@ -60,17 +61,12 @@ class _HomePageState extends State<HomePage> {
           ),
           actions: [
             TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: const Text("I'll decide later"),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              child: const Text('Allow tracking'),
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Continue'),
             ),
           ],
         ),
-      ) ??
-      false;
+      );
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app_tracking_transparency.dart
+++ b/lib/app_tracking_transparency.dart
@@ -33,12 +33,11 @@ class AppTrackingTransparency {
   /// if (await AppTrackingTransparency.trackingAuthorizationStatus ==
   ///     TrackingStatus.notDetermined) {
   ///   // Show a custom explainer dialog before the system dialog
-  ///   if (await showCustomTrackingDialog(context)) {
-  ///     // Wait for dialog popping animation
-  ///     await Future.delayed(const Duration(milliseconds: 200));
-  ///     // Request system's tracking authorization dialog
-  ///     await AppTrackingTransparency.requestTrackingAuthorization();
-  ///   }
+  ///   await showCustomTrackingDialog(context);
+  ///   // Wait for dialog popping animation
+  ///   await Future.delayed(const Duration(milliseconds: 200));
+  ///   // Request system's tracking authorization dialog
+  ///   await AppTrackingTransparency.requestTrackingAuthorization();
   /// }
   /// ```
   ///


### PR DESCRIPTION
Apple does not allow Decide later button in explainer dialog (#27). Also Google updated their guide to include only a Continue button (https://support.google.com/admob/answer/10115027?hl=en).

![v7GokkrtuxKhV5lYTjfANyoi3Q3O1UlDTQBV.png](https://user-images.githubusercontent.com/54450843/163704377-3d41ad96-1c50-449b-925d-698a66808c13.png)

I updated readme, documentation and example code with this change.