### PR TITLE
Add Swift Package Manager support for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 build/
 
+example/ios/Flutter/ephemeral/
+
 # Cleanliness
 pubspec.lock
 **.iml

--- a/ios/app_tracking_transparency/Package.swift
+++ b/ios/app_tracking_transparency/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "app_tracking_transparency",
+    platforms: [
+        .iOS("13.0")
+    ],
+    products: [
+        .library(
+            name: "app-tracking-transparency",
+            targets: ["app_tracking_transparency"]
+        )
+    ],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
+    targets: [
+        .target(
+            name: "app_tracking_transparency",
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
+            path: "Sources/app_tracking_transparency",
+            resources: [
+                .process("PrivacyInfo.xcprivacy")
+            ]
+        )
+    ]
+)

--- a/ios/app_tracking_transparency/Sources/app_tracking_transparency/AppTrackingTransparencyPlugin.swift
+++ b/ios/app_tracking_transparency/Sources/app_tracking_transparency/AppTrackingTransparencyPlugin.swift
@@ -1,0 +1,84 @@
+import Flutter
+import UIKit
+import AppTrackingTransparency
+import AdSupport
+
+public class AppTrackingTransparencyPlugin: NSObject, FlutterPlugin {
+  private var observer: NSObjectProtocol?
+  
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: "app_tracking_transparency", binaryMessenger: registrar.messenger())
+    let instance = AppTrackingTransparencyPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    if (call.method == "getTrackingAuthorizationStatus") {
+        getTrackingAuthorizationStatus(result: result)
+    }
+    else if (call.method == "requestTrackingAuthorization") {
+        requestTrackingAuthorization(result: result)
+    }
+    else if (call.method == "getAdvertisingIdentifier") {
+        getAdvertisingIdentifier(result: result)
+    }
+    else {
+        result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func getTrackingAuthorizationStatus(result: @escaping FlutterResult) {
+    if #available(iOS 14, *) {
+        result(Int(ATTrackingManager.trackingAuthorizationStatus.rawValue))
+    } else {
+        // return notSupported
+        result(Int(4))
+    }
+  }
+
+  /*
+    case notDetermined = 0
+    case restricted = 1
+    case denied = 2
+    case authorized = 3
+  */
+  private func requestTrackingAuthorization(result: @escaping FlutterResult) {
+    if #available(iOS 14, *) {
+         removeObserver()
+
+        ATTrackingManager.requestTrackingAuthorization{ [weak self] status in
+            if status == .denied, ATTrackingManager.trackingAuthorizationStatus == .notDetermined {
+                    print("iOS 17.4 authorization bug detected")
+                    self?.addObserver(result: result)
+                    return
+            }
+            result(Int(status.rawValue))
+        }
+    } else {
+        // return notSupported
+        result(Int(4))
+    }
+  }
+
+  private func getAdvertisingIdentifier(result: @escaping FlutterResult) {
+    result(String(ASIdentifierManager.shared().advertisingIdentifier.uuidString))
+  }
+
+  private func addObserver(result: @escaping FlutterResult) {
+    removeObserver()
+    observer = NotificationCenter.default.addObserver(
+        forName: UIApplication.didBecomeActiveNotification,
+        object: nil,
+        queue: .main
+    ) { [weak self] _ in
+        self?.requestTrackingAuthorization(result: result)
+    }
+  }
+
+  private func removeObserver() {
+    if let observer = observer {
+        NotificationCenter.default.removeObserver(observer)
+        self.observer = nil
+    }
+  }
+}

--- a/ios/app_tracking_transparency/Sources/app_tracking_transparency/PrivacyInfo.xcprivacy
+++ b/ios/app_tracking_transparency/Sources/app_tracking_transparency/PrivacyInfo.xcprivacy
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false />
+    <key>NSPrivacyTrackingDomains</key>
+    <array />
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyCollectedDataType</key>
+        <string>NSPrivacyCollectedDataTypeDeviceID</string>
+        <key>NSPrivacyCollectedDataTypeLinked</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypeTracking</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypePurposes</key>
+        <array>
+          <string>NSPrivacyCollectedDataTypePurposeThirdPartyAdvertising</string>
+        </array>
+      </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array />
+  </dict>
+</plist>


### PR DESCRIPTION
## Summary

This PR adds Swift Package Manager support for the iOS implementation while keeping the existing CocoaPods integration intact.

## Changes

- Added `ios/app_tracking_transparency/Package.swift`
- Added SPM source layout under `ios/app_tracking_transparency/Sources/app_tracking_transparency/`
- Added an SPM-compatible plugin class named `AppTrackingTransparencyPlugin`
- Included `PrivacyInfo.xcprivacy` in the SPM target resources
- Kept the existing CocoaPods files unchanged for backwards compatibility
- Updated `.gitignore` to avoid committing generated Flutter iOS files

## Notes

The SPM package uses iOS 13.0 as its minimum platform version. The AppTrackingTransparency APIs are still guarded with availability checks, so this avoids unnecessarily forcing apps to raise their deployment target to iOS 14.

## Testing

Tested with a local Flutter app using:

```bash
flutter config --enable-swift-package-manager
flutter clean
flutter pub get
flutter run